### PR TITLE
Add shooting game entry and mobile grid tweak

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,7 +24,8 @@ const gameData = [
     { title: '平和な世界', category: 'adventure', keywords: '平和 世界 癒し', url: 'https://titan11111.github.io/25-heiwa/', icon: '🕊️' },
     { title: '坊主めくり', category: 'quiz', keywords: '坊主 めくり カード 伝統', url: 'https://titan11111.github.io/26-bouzu/', icon: '🎴' },
     { title: '迷いの森', category: 'adventure', keywords: '森 迷い 神秘 探索', url: 'https://titan11111.github.io/27-mayoimori/', icon: '🌲' },
-    { title: 'クイズ３', category: 'quiz', keywords: 'クイズ 問題 頭脳', url: 'https://titan11111.github.io/28-quiz3/', icon: '🧠' }
+    { title: 'クイズ３', category: 'quiz', keywords: 'クイズ 問題 頭脳', url: 'https://titan11111.github.io/28-quiz3/', icon: '🧠' },
+    { title: 'シュートゲーム', category: 'action', keywords: 'shoot シュート 射撃', url: 'https://titan11111.github.io/31-shoot/', icon: '🔫' }
 ];
 
 // カテゴリー情報
@@ -149,7 +150,8 @@ function generateDescription(game) {
         '平和な世界': '癒しの平和な空間',
         '坊主めくり': '伝統的なカードゲーム',
         '迷いの森': '神秘的な森を探索しよう',
-        'クイズ３': '頭脳を鍛えるクイズ'
+        'クイズ３': '頭脳を鍛えるクイズ',
+        'シュートゲーム': '的を狙ってシュート！'
     };
     
     return descriptions[game.title] || '楽しいゲームを体験しよう！';

--- a/style.css
+++ b/style.css
@@ -486,7 +486,7 @@ body {
   }
   
   .games-grid {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2, 1fr);
       gap: 15px;
   }
 


### PR DESCRIPTION
## Summary
- register new shooting game `31-shoot`
- provide short description for the new game
- show game buttons in two columns on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a0b0f00bc8330bc0e74bd5ae54cf1