### PR TITLE
Improve game grid layout and button design

### DIFF
--- a/style.css
+++ b/style.css
@@ -328,19 +328,19 @@ body {
 
 .games-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 25px;
   margin-bottom: 40px;
 }
 
 .game-button {
-  background: linear-gradient(145deg, #ffffff, #f8f9fa);
-  border: none;
+  background: linear-gradient(145deg, #e0e0e0, #ffffff);
+  border: 2px solid #b3b3b3;
   border-radius: var(--border-radius);
   padding: 25px 20px;
   cursor: pointer;
   transition: var(--transition);
-  box-shadow: var(--shadow-light);
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.3), inset 0 2px 4px rgba(255, 255, 255, 0.5);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -352,19 +352,18 @@ body {
   opacity: 1;
   transform: scale(1);
   min-height: 160px;
-  border: 2px solid transparent;
 }
 
 .game-button:hover {
   transform: translateY(-8px) scale(1.03);
-  box-shadow: var(--shadow-heavy);
-  background: linear-gradient(145deg, #f8f9fa, #ffffff);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(145deg, #f8f9fa, #e0e0e0);
   border-color: var(--accent-color);
 }
 
 .game-button:active {
   transform: translateY(-4px) scale(0.98);
-  box-shadow: var(--shadow-medium);
+  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.3);
 }
 
 .game-button:focus {
@@ -750,7 +749,7 @@ body {
   }
   
   .games-grid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 20px;
   }
   
@@ -1021,6 +1020,8 @@ body {
   .game-button {
     background: linear-gradient(145deg, #2d3748, #4a5568);
     color: #e2e8f0;
+    border: 2px solid #1a202c;
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.6), inset 0 2px 4px rgba(255, 255, 255, 0.1);
   }
   
   .game-title {


### PR DESCRIPTION
## Summary
- display games in a fixed two-column grid
- restyle game buttons with thicker borders and stronger shadows for a heavier feel
- ensure dark mode keeps the new button styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cb90d7a64833094df643f1646edd5