### PR TITLE
Add nekubi game to portal

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // ゲームデータ（新しいゲームを追加）
 const gameData = [
+    { title: 'ねくび', category: 'adventure', keywords: 'ねくび 眠り', url: 'https://titan11111.github.io/33--nekubi/', icon: '😴', isNew: true },
     { title: 'シューティング2', category: 'action', keywords: 'シューティング 射撃 連射', url: 'https://titan11111.github.io/32-shoot2/', icon: '🎯', isNew: true },
     { title: 'シューティング1', category: 'action', keywords: 'シューティング 射撃', url: 'https://titan11111.github.io/31-shoot/', icon: '🔫', isNew: true },
     { title: 'ゆぐどら', category: 'adventure', keywords: '神秘 ファンタジー 冒険 世界樹', url: 'https://titan11111.github.io/30-yugudora/', icon: '🌳', isNew: true },


### PR DESCRIPTION
## Summary
- add new game entry "ねくび" pointing to https://titan11111.github.io/33--nekubi/ and mark as new

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d514071ac8330a0ad677abb41753d