### PR TITLE
feat: render emojis as SVG icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🎮 魔法のゲームポータル | 楽しいゲーム大集合！</title>
+    <title>魔法のゲームポータル | 楽しいゲーム大集合！</title>
     
     <!-- SEO対策 -->
     <meta name="description" content="小学生から大人まで楽しめるゲームポータルサイト。アクション、クイズ、アドベンチャーなど様々なジャンルのゲームを用意しています。">
@@ -13,14 +13,14 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="">
-    <meta property="og:title" content="🎮 魔法のゲームポータル">
+    <meta property="og:title" content="魔法のゲームポータル">
     <meta property="og:description" content="楽しいゲームがいっぱい！小学生から大人まで遊べるゲーム集">
     <meta property="og:image" content="">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="">
-    <meta property="twitter:title" content="🎮 魔法のゲームポータル">
+    <meta property="twitter:title" content="魔法のゲームポータル">
     <meta property="twitter:description" content="楽しいゲームがいっぱい！小学生から大人まで遊べるゲーム集">
     <meta property="twitter:image" content="">
     
@@ -31,8 +31,8 @@
     <meta name="apple-mobile-web-app-title" content="ゲームポータル">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎮</text></svg>">
-    <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎮</text></svg>">
+    <link rel="icon" type="image/svg+xml" href="https://twemoji.maxcdn.com/v/latest/svg/1f3ae.svg">
+    <link rel="apple-touch-icon" href="https://twemoji.maxcdn.com/v/latest/svg/1f3ae.svg">
     
     <!-- Preload重要なリソース -->
     <link rel="preload" href="style.css" as="style">
@@ -369,7 +369,7 @@
                 type="text" 
                 id="searchInput" 
                 class="search-input" 
-                placeholder="🔍 ゲームを検索してみよう..."
+                placeholder="ゲームを検索してみよう..."
                 autocomplete="off"
                 role="searchbox"
                 aria-label="ゲーム検索"
@@ -451,6 +451,7 @@
     </div>
 
     <!-- スクリプト -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/twemoji.min.js" crossorigin="anonymous"></script>
     <script src="script.js"></script>
     
     <!-- 読み込み完了時の処理 -->
@@ -672,12 +673,12 @@
             orientation: "portrait",
             icons: [
                 {
-                    src: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>",
+                    src: "https://twemoji.maxcdn.com/v/latest/svg/1f3ae.svg",
                     sizes: "192x192",
                     type: "image/svg+xml"
                 },
                 {
-                    src: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>",
+                    src: "https://twemoji.maxcdn.com/v/latest/svg/1f3ae.svg",
                     sizes: "512x512",
                     type: "image/svg+xml"
                 }

--- a/script.js
+++ b/script.js
@@ -1060,3 +1060,22 @@ additionalStyles.textContent = `
     }
 `;
 document.head.appendChild(additionalStyles);
+
+// Emoji to SVG conversion
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.twemoji) {
+        const parseOptions = { folder: 'svg', ext: '.svg', className: 'emoji' };
+        twemoji.parse(document.body, parseOptions);
+
+        const observer = new MutationObserver(mutations => {
+            mutations.forEach(m => {
+                m.addedNodes.forEach(node => {
+                    if (node.nodeType === 1 || node.nodeType === 3) {
+                        twemoji.parse(node, parseOptions);
+                    }
+                });
+            });
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -25,6 +25,12 @@ body {
   overflow-x: hidden;
 }
 
+.emoji {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: -0.2em;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;
@@ -176,9 +182,21 @@ body {
   margin-right: auto;
 }
 
+.search-container::before {
+  content: '';
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.2em;
+  height: 1.2em;
+  background: url('https://twemoji.maxcdn.com/v/latest/svg/1f50d.svg') no-repeat center/contain;
+  pointer-events: none;
+}
+
 .search-input {
   width: 100%;
-  padding: 18px 25px;
+  padding: 18px 25px 18px 55px;
   font-size: 1.1rem;
   border: none;
   border-radius: 50px;


### PR DESCRIPTION
## Summary
- replace favicon and manifest emojis with SVG images
- convert all page emojis to SVG icons using Twemoji
- style search bar with SVG search icon and enlarge emoji icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d813686f4833087fce7a020d69998