### PR TITLE
Use SVG emoji images at larger size

### DIFF
--- a/script.js
+++ b/script.js
@@ -1071,12 +1071,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const observer = new MutationObserver(mutations => {
             mutations.forEach(m => {
                 m.addedNodes.forEach(node => {
-                    if (node.nodeType === 1 || node.nodeType === 3) {
+                    if (node.nodeType === 1) {
                         twemoji.parse(node, parseOptions);
+                    } else if (node.nodeType === 3 && node.parentNode) {
+                        twemoji.parse(node.parentNode, parseOptions);
                     }
                 });
+                if (m.type === 'characterData' && m.target.parentNode) {
+                    twemoji.parse(m.target.parentNode, parseOptions);
+                }
             });
         });
-        observer.observe(document.body, { childList: true, subtree: true });
+        observer.observe(document.body, { childList: true, subtree: true, characterData: true });
     }
 });

--- a/style.css
+++ b/style.css
@@ -26,8 +26,8 @@ body {
 }
 
 .emoji {
-  width: 1.2em;
-  height: 1.2em;
+  width: 1.3em;
+  height: 1.3em;
   vertical-align: -0.2em;
 }
 


### PR DESCRIPTION
## Summary
- Ensure all emoji are converted to SVG via Twemoji, including dynamic updates.
- Display emoji images at 130% scale for better visibility.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d97128a10833080b45f7a833512e4