### PR TITLE
セレクト画面BGM音量を80%に調整

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@
 let selectBGM = null;
 window.addEventListener('DOMContentLoaded', () => {
     selectBGM = new Audio('audio/Entering_the_core.mp3');
-    selectBGM.volume = 0.4;
+    selectBGM.volume = 0.8;
     selectBGM.loop = true;
 
     const startBGM = () => {


### PR DESCRIPTION
## Summary
- セレクト画面のBGM音量を40%から80%に引き上げました

## Testing
- `npm test` *(package.json が存在しないため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689066328c4c8330b28d0d5f601062b6