### PR TITLE
feat: stop select BGM on game launch

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,6 +88,12 @@ const achievements = [
 
 // ゲームを開く関数（改良版）
 function playGame(gameUrl) {
+    // セレクトBGMを停止
+    if (selectBGM && !selectBGM.paused) {
+        selectBGM.pause();
+        selectBGM.currentTime = 0;
+    }
+
     playClickSound();
     
     // ボタンのアニメーション効果


### PR DESCRIPTION
## Summary
- stop background music when a game is selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e7a4ba908330bad293a1a97abfe3