### PR TITLE
Stop select BGM from pausing when launching a game

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,12 +88,6 @@ const achievements = [
 
 // ゲームを開く関数（改良版）
 function playGame(gameUrl) {
-    // セレクトBGMを停止
-    if (selectBGM && !selectBGM.paused) {
-        selectBGM.pause();
-        selectBGM.currentTime = 0;
-    }
-
     playClickSound();
     
     // ボタンのアニメーション効果


### PR DESCRIPTION
## Summary
- Keep selection screen BGM playing when a game is opened

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e8c2714083308b1b0fa32aeff5cd