### PR TITLE
Add links for Matou and Nekubi2 games

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,8 @@
 
 // ゲームデータ（新しいゲームを追加）
 const gameData = [
+    { title: '魔塔：闇の塔の試練', category: 'adventure', keywords: '魔塔 塔 ダンジョン', url: 'https://titan11111.github.io/45-matou/', icon: '🗼', isNew: true },
+    { title: 'ねくび2：夢幻の冒険', category: 'adventure', keywords: 'ねくび 眠り 夢', url: 'https://titan11111.github.io/44-nekubi2/', icon: '😴', isNew: true },
     { title: '格闘チャンピオン2：最強の挑戦者', category: 'battle action', keywords: '格闘 バトル 対戦', url: 'https://titan11111.github.io/43-kakuge2/', icon: '🥊', isNew: true },
     { title: 'シューティング4：天空の激戦', category: 'action', keywords: 'シューティング 宇宙 弾幕', url: 'https://titan11111.github.io/42-syutinngu/', icon: '🚀', isNew: true },
     { title: 'ホラー脱出2：闇夜の再来', category: 'adventure', keywords: 'ホラー 怖い 脱出', url: 'https://titan11111.github.io/41-horaa2/', icon: '👻', isNew: true },


### PR DESCRIPTION
## Summary
- add Matou: 闇の塔の試練 to game list
- add Nekubi2: 夢幻の冒険 to game list

## Testing
- `npm test` (fails: package.json not found)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689733d5bb6c8330925e36aa4e2ea909