### PR TITLE
Add RPG and shooting categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,8 @@
       <div class="filter-buttons">
         <button class="filter-btn active" data-category="all">すべて</button>
         <button class="filter-btn" data-category="action">アクション</button>
+        <button class="filter-btn" data-category="rpg">RPG</button>
+        <button class="filter-btn" data-category="shooting">シューティング</button>
         <button class="filter-btn" data-category="adventure">アドベンチャー</button>
         <button class="filter-btn" data-category="battle">バトル</button>
         <button class="filter-btn" data-category="quiz">クイズ</button>
@@ -335,6 +337,27 @@
       { title:'化合物クイズ：サイエンスピース', category:'quiz learning', keywords:'化合物 科学 理科 クイズ', url:'https://titan11111.github.io/2-kagoubutu_game/', icon:'🧪' },
       { title:'ねこキャッチ：すばやく捕まえよう', category:'action', keywords:'ねこ 猫 キャッチ 動物', url:'https://titan11111.github.io/1-neko_catch_game/', icon:'🐱' }
     ];
+
+    // カテゴリーの正規化
+    function normalizeCategory(game){
+      const text = (game.title + ' ' + game.keywords).toLowerCase();
+      if(text.includes('rpg')){
+        game.category = 'rpg';
+      }else if(text.includes('シューティング') || text.includes('shoot')){
+        game.category = 'shooting';
+      }else if(game.category.includes('battle')){
+        game.category = 'battle';
+      }else if(game.category.includes('quiz')){
+        game.category = 'quiz';
+      }else if(game.category.includes('learning')){
+        game.category = 'learning';
+      }else if(game.category.includes('action')){
+        game.category = 'action';
+      }else{
+        game.category = 'adventure';
+      }
+    }
+    gameData.forEach(normalizeCategory);
 
     // グローバル
     let currentPage = 1;

--- a/script.js
+++ b/script.js
@@ -62,6 +62,27 @@ const gameData = [
     { title: 'ねこキャッチ：すばやく捕まえよう', category: 'action', keywords: 'ねこ 猫 キャッチ 動物', url: 'https://titan11111.github.io/1-neko_catch_game/', icon: '🐱' }
 ];
 
+// カテゴリーの正規化
+function normalizeCategory(game) {
+    const text = (game.title + ' ' + game.keywords).toLowerCase();
+    if (text.includes('rpg')) {
+        game.category = 'rpg';
+    } else if (text.includes('シューティング') || text.includes('shoot')) {
+        game.category = 'shooting';
+    } else if (game.category.includes('battle')) {
+        game.category = 'battle';
+    } else if (game.category.includes('quiz')) {
+        game.category = 'quiz';
+    } else if (game.category.includes('learning')) {
+        game.category = 'learning';
+    } else if (game.category.includes('action')) {
+        game.category = 'action';
+    } else {
+        game.category = 'adventure';
+    }
+}
+gameData.forEach(normalizeCategory);
+
 // グローバル変数
 let currentPage = 1;
 let itemsPerPage = 12;


### PR DESCRIPTION
## Summary
- Add RPG and shooting filter buttons to categorize games more clearly
- Normalize game categories based on titles and keywords so RPG and shooting games are properly grouped

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c748060f20833083bde365626fd1a6